### PR TITLE
EA-2224: Remove CORS header from Nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -62,14 +62,6 @@ http {
         server {{env "RECOMMENDATION_API_HOST"}};
     }
 
-    # When there is no Access-Control-Allow-Origin header make variable $CorsValue an empty string, else set value "*"
-    # The map is used as a workaround because we can't check upstream header values with if statements in a location block
-    # See also https://stackoverflow.com/q/31017524
-    map $upstream_http_access_control_allow_origin $CorsValue {
-        "" "";
-        default "*";
-    }
-
     server {
         listen {{port}};
         root public;
@@ -104,9 +96,6 @@ http {
         # Not sure why we have this rule and if it's still useful.
         location ~ ^/api/(.*) {
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://search_api/api/$1$is_args$args;
         }
         
@@ -148,18 +137,12 @@ http {
         # Search API
         location ~ ^/record/(v2/)?(open)?search(.*) {
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://search_api/api/v2/$2search$3$is_args$args;
         }
 
         # Record API
         location ~ ^/record/(v2/)?(.*) {
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://search_api/api/v2/record/$2$is_args$args;
         }
 
@@ -176,9 +159,6 @@ http {
             # Thumbnails are JPEGs; no need to gzip them
             gzip off;
             proxy_set_header Host {{env "THUMBNAIL_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://thumbnail_api;
         }
         
@@ -187,9 +167,6 @@ http {
             # Thumbnails are JPEGs; no need to gzip them
             gzip off;
             proxy_set_header Host {{env "THUMBNAIL_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json;
         }
         
@@ -203,18 +180,12 @@ http {
             # Thumbnails are JPEGs; no need to gzip them
             gzip off;
             proxy_set_header Host {{env "THUMBNAIL_API_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
         }
 
         # OAI-PMH requests
         location = /oai/record {
             proxy_set_header Host {{env "OAI_RECORD_HOST"}};
-            # EA-1990 if CORS header in response then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://oai_record/oai/$is_args$args;
         }
         
@@ -244,27 +215,18 @@ http {
         # Entity API
         location ~ ^/entity/(.*) {
             proxy_set_header Host {{env "ENTITY_API_HOST"}};
-            # EA-1990 if CORS header in response, then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://entity_api/entity/$1$is_args$args;
         }
 
         # Manifest API
         location ~ ^/presentation/(.*)/manifest$ {
             proxy_set_header Host {{env "MANIFEST_API_HOST"}};
-            # EA-1990 if CORS header in response, then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
         }
 
         # Fulltext API
         location ~ ^/(fulltext|presentation)/(.*) {
             proxy_set_header Host {{env "FULLTEXT_API_HOST"}};
-            # EA-1990 if CORS header in response, then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://fulltext_api/presentation/$2$is_args$args;
         }
 
@@ -283,9 +245,6 @@ http {
         # Sets API
         location ~ ^/set/(.*) {
             proxy_set_header Host {{env "SET_API_HOST"}};
-            # EA-1990 if CORS header in response, then replace value with * (temporary measure)
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin $CorsValue always;
             proxy_pass http://set_api/set/$1$is_args$args;
         }
         


### PR DESCRIPTION
- `Access-Control-Allow-Origin` header now added by API servers