### PR TITLE
EA-2276: Disable URL decoding in Nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NB: ensure the version matches that in buildpack.yml
-FROM nginx:1.15.8
+FROM nginx:1.19.3
 
 MAINTAINER Europeana Foundation <development@europeana.eu>
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -150,7 +150,7 @@ http {
 
         # Search API
         location ~ ^/record/(v2/)?(open)?search(.*) {
-            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/search$3 break;
+            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
             # EA-1990 if CORS header in response then replace value with * (temporary measure)
             proxy_hide_header Access-Control-Allow-Origin;

--- a/nginx.conf
+++ b/nginx.conf
@@ -150,7 +150,7 @@ http {
 
         # Search API
         location ~ ^/record/(v2/)?(open)?search(.*) {
-            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/record/$3 break;
+            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/search$3 break;
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
             # EA-1990 if CORS header in response then replace value with * (temporary measure)
             proxy_hide_header Access-Control-Allow-Origin;

--- a/nginx.conf
+++ b/nginx.conf
@@ -91,13 +91,6 @@ http {
             return 302 {{env "ROOT_REDIRECT_URL"}};
         }
 
-        
-        # Redirect old thumbnail url format
-        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
-        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
-        location = /api/image {
-            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
-        }
 
         # Old and deprecated (kept for the time being for backward compatibility)
         # ----------------------------------------------------------
@@ -119,6 +112,13 @@ http {
             proxy_pass http://search_api;
         }
         
+      
+        # Redirect old thumbnail url format
+        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
+        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
+        location = /api/image {
+            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
+        }
         
         # Redirect old oai-pmh requests (added June 2019)
         location = /oaicat/OAIHandler {

--- a/nginx.conf
+++ b/nginx.conf
@@ -91,6 +91,14 @@ http {
             return 302 {{env "ROOT_REDIRECT_URL"}};
         }
 
+        
+        # Redirect old thumbnail url format
+        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
+        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
+        location = /api/image {
+            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
+        }
+
         # Old and deprecated (kept for the time being for backward compatibility)
         # ----------------------------------------------------------
         # Redirect old record url format (to be removed?)
@@ -103,19 +111,14 @@ http {
 
         # Not sure why we have this rule and if it's still useful.
         location ~ ^/api/(.*) {
+            rewrite ^/api/(.*)$ /api/$1 break;
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
             # EA-1990 if CORS header in response then replace value with * (temporary measure)
             proxy_hide_header Access-Control-Allow-Origin;
             add_header Access-Control-Allow-Origin $CorsValue always;
-            proxy_pass http://search_api/api/$1$is_args$args;
+            proxy_pass http://search_api;
         }
         
-        # Redirect old thumbnail url format
-        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
-        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
-        location = /api/image {
-            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
-        }
         
         # Redirect old oai-pmh requests (added June 2019)
         location = /oaicat/OAIHandler {
@@ -147,20 +150,22 @@ http {
 
         # Search API
         location ~ ^/record/(v2/)?(open)?search(.*) {
+            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/record/$3 break;
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
             # EA-1990 if CORS header in response then replace value with * (temporary measure)
             proxy_hide_header Access-Control-Allow-Origin;
             add_header Access-Control-Allow-Origin $CorsValue always;
-            proxy_pass http://search_api/api/v2/$2search$3$is_args$args;
+            proxy_pass http://search_api;
         }
 
         # Record API
         location ~ ^/record/(v2/)?(.*) {
+            rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
             proxy_set_header Host {{env "SEARCH_API_HOST"}};
             # EA-1990 if CORS header in response then replace value with * (temporary measure)
             proxy_hide_header Access-Control-Allow-Origin;
             add_header Access-Control-Allow-Origin $CorsValue always;
-            proxy_pass http://search_api/api/v2/record/$2$is_args$args;
+            proxy_pass http://search_api;
         }
 
         # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)


### PR DESCRIPTION
 Nginx by default decodes URLs before proxying, which leads to an error when URLs contain the whitespace character (%20).

With this PR, URLs are forwarded as-is to the Search & Record API upstream server.