### PR TITLE
Changes to Api Gateway per April 10

### DIFF
--- a/env-nginx
+++ b/env-nginx
@@ -20,7 +20,7 @@ vars='$ANNOTATION_API_HOST
       $RECOMMENDATION_API_HOST
       $TRANSLATION_API_HOST
       $NEWSPAPER_API_HOST
-      $API_GATEWAY_HOST'
+      $KEYCLOAK_HOST'
 
 envsubst "${vars}" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 

--- a/env-nginx
+++ b/env-nginx
@@ -19,8 +19,7 @@ vars='$ANNOTATION_API_HOST
       $THUMBNAIL_API_HOST
       $RECOMMENDATION_API_HOST
       $TRANSLATION_API_HOST
-      $NEWSPAPER_API_HOST
-      $KEYCLOAK_HOST'
+      $NEWSPAPER_API_HOST'
 
 envsubst "${vars}" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -8,8 +8,7 @@ metadata:
   name: api-gateway-ingress
   annotations:
     cert-manager.io/issuer: letsencrypt-production
-#    nginx.ingress.kubernetes.io/permanent-redirect: ${K8S_HOSTNAME}
-    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
+#    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
 spec:
   ingressClassName: public-iks-k8s-nginx
   tls:

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -8,6 +8,8 @@ metadata:
   name: api-gateway-ingress
   annotations:
     cert-manager.io/issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/permanent-redirect: ${K8S_HOSTNAME}
+    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
 spec:
   ingressClassName: public-iks-k8s-nginx
   tls:

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -9,7 +9,7 @@ metadata:
   annotations:
     cert-manager.io/issuer: letsencrypt-production
 #    nginx.ingress.kubernetes.io/permanent-redirect: ${K8S_HOSTNAME}
-#    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
+    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
 spec:
   ingressClassName: public-iks-k8s-nginx
   tls:

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -8,8 +8,8 @@ metadata:
   name: api-gateway-ingress
   annotations:
     cert-manager.io/issuer: letsencrypt-production
-    nginx.ingress.kubernetes.io/permanent-redirect: ${K8S_HOSTNAME}
-    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
+#    nginx.ingress.kubernetes.io/permanent-redirect: ${K8S_HOSTNAME}
+#    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
 spec:
   ingressClassName: public-iks-k8s-nginx
   tls:

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -8,7 +8,6 @@ metadata:
   name: api-gateway-ingress
   annotations:
     cert-manager.io/issuer: letsencrypt-production
-#    nginx.ingress.kubernetes.io/permanent-redirect-code: '308'
 spec:
   ingressClassName: public-iks-k8s-nginx
   tls:

--- a/mime.types
+++ b/mime.types
@@ -25,6 +25,7 @@ types {
   image/x-ms-bmp bmp;
   image/svg+xml svg svgz;
   image/webp webp;
+  application/ld+json jsonld json-ld;
   application/java-archive jar war ear;
   application/mac-binhex40 hqx;
   application/msword doc;

--- a/nginx.conf.d/http-server-proxy.conf
+++ b/nginx.conf.d/http-server-proxy.conf
@@ -1,8 +1,4 @@
-proxy_buffering off;
-proxy_buffer_size 2k;
-proxy_buffers 100 128k;
 proxy_http_version 1.1;
-proxy_max_temp_file_size 0;
 proxy_read_timeout 300s;
 proxy_ssl_server_name on;
 proxy_connect_timeout 30s;

--- a/nginx.conf.d/http-server-proxy.conf
+++ b/nginx.conf.d/http-server-proxy.conf
@@ -1,10 +1,8 @@
-proxy_buffering off;
-proxy_buffer_size 2k;
-proxy_buffers 100 128k;
 proxy_http_version 1.1;
-proxy_max_temp_file_size 0;
 proxy_read_timeout 300s;
 proxy_ssl_server_name on;
 proxy_connect_timeout 30s;
 proxy_set_header Connection "";
+client_body_buffer_size 16k;
+large_client_header_buffers 4 16k;
 proxy_ignore_headers Cache-Control Vary;

--- a/nginx.conf.d/http-server-proxy.conf
+++ b/nginx.conf.d/http-server-proxy.conf
@@ -1,4 +1,8 @@
+proxy_buffering off;
+proxy_buffer_size 2k;
+proxy_buffers 100 128k;
 proxy_http_version 1.1;
+proxy_max_temp_file_size 0;
 proxy_read_timeout 300s;
 proxy_ssl_server_name on;
 proxy_connect_timeout 30s;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -82,6 +82,11 @@ http {
         server ${NEWSPAPER_API_HOST};
     }
 
+    upstream keycloak {
+        keepalive 10;
+        server ${KEYCLOAK_HOST};
+    }
+
 
     server {
         listen 80 default_server;
@@ -217,7 +222,29 @@ http {
                 return 301 https://$host/oai/record/$1.html;
             }
 
+
             # ----------------------------------------------------------
+
+
+            # EA-3761
+            location ~ ^/(auth)/(protocol/openid-connect|account) {
+                set $openid $1/realms/europeana/$2;
+                proxy_set_header Host ${KEYCLOAK_HOST};
+                proxy_pass https://keycloak/$openid;
+            }
+
+            location ~ ^/(auth)/?$ {
+                proxy_set_header Host ${KEYCLOAK_HOST};
+                proxy_pass https://keycloak/$1/;
+            }
+
+
+            location ~* /translation/(.*) {
+                rewrite ^/translation/ /$1 break;
+                proxy_set_header Host ${TRANSLATION_API_HOST};
+                proxy_pass https://translation_api/$1;
+            }
+
 
             # Recommendation API (alternative path, has to be defined before Search & Record)
             location ~ ^/record/(v2/)?(.*)/recommend {

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -24,80 +24,96 @@ http {
     # Note that for upstream servers all IP addresses/services need to be available on start-up!
     upstream annotation_api {
         keepalive 10;
-        server ${ANNOTATION_API_HOST};
+        server ${
+            ANNOTATION_API_HOST
+        };
     }
 
     upstream entity_api {
         keepalive 10;
-        server ${ENTITY_API_HOST};
+        server ${
+            ENTITY_API_HOST
+        };
     }
 
     upstream entity_management {
         keepalive 10;
-        server ${ENTITY_MANAGEMENT_HOST};
+        server ${
+            ENTITY_MANAGEMENT_HOST
+        };
     }
 
     upstream fulltext_api {
         keepalive 10;
-        server ${FULLTEXT_API_HOST};
+        server ${
+            FULLTEXT_API_HOST
+        };
     }
 
     upstream manifest_api {
         keepalive 10;
-        server ${MANIFEST_API_HOST};
+        server ${
+            MANIFEST_API_HOST
+        };
     }
 
     upstream oai_record {
         keepalive 10;
-        server ${OAI_RECORD_HOST};
+        server ${
+            OAI_RECORD_HOST
+        };
     }
 
     upstream recommendation_api {
         keepalive 10;
-        server ${RECOMMENDATION_API_HOST};
+        server ${
+            RECOMMENDATION_API_HOST
+        };
     }
 
     upstream search_api {
         keepalive 10;
-        server ${SEARCH_API_HOST};
+        server ${
+            SEARCH_API_HOST
+        };
     }
 
     upstream set_api {
         keepalive 10;
-        server ${SET_API_HOST};
+        server ${
+            SET_API_HOST
+        };
     }
 
     upstream thumbnail_api {
         keepalive 10;
-        server ${THUMBNAIL_API_HOST};
+        server ${
+            THUMBNAIL_API_HOST
+        };
     }
 
     upstream translation_api {
         keepalive 10;
-        server ${TRANSLATION_API_HOST}:443;
+        server ${
+            TRANSLATION_API_HOST
+        }
+        :443;
     }
 
     upstream newspaper_api {
         keepalive 10;
-        server ${NEWSPAPER_API_HOST};
+        server ${
+            NEWSPAPER_API_HOST
+        };
     }
 
 
     server {
         listen 80 default_server;
-#         server_name ${API_GATEWAY_HOST};
-#         return 308 https://$host$request_uri;
-#     }
-
-
-#     server {
-#         listen 443 default_server;
-#         server_name ${API_GATEWAY_HOST};
         root /usr/share/nginx/html;
         index index.html;
 
         # HTTPS enforcement should be done within Kubernetes ingress
-        # so I have some doubts if the above 308 redirection is fully OK?
         # "upstream" servers do not use resolver settings by default (paid option), so we proxy directly to the urls
         #resolver ${RESOLVER_SETTINGS};
 
@@ -105,225 +121,310 @@ http {
 
         include nginx.conf.d/*.conf;
 
-        # Redirect root
-        location = / {
-            return 302 ${ROOT_REDIRECT_URL};
-        }
 
-        # Used by Kubernetes health checks
-        location /nginx-health {
-            default_type application/json;
-            return 200 '{"status":"healthy"}';
-        }
+        server {
+            listen 8088 default_server;
+            server_name localhost;
+            root /usr/local/etc/nginx/public;
+            #         listen 80;
+            #         root /usr/share/nginx/html;
+            index index.html;
 
-        location ~* ^/test/(.*) {
-            return 200 '$1';
-        }
+            # ----------------------------------------------------------
+            #
+		    # Wide-open CORS config for nginx
+            #
+            # ----------------------------------------------------------
+            location / {
+                if ($request_method = 'OPTIONS') {
+                    add_header 'Access-Control-Allow-Origin' '*';
+                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                    #
+				    # Custom headers and headers various browsers *should* be OK with but aren't
+                    #
 
-        # no rewrite needed for proxying HOST requests
-        location ~* ^/translation/(translate|detect) {
-            proxy_set_header Host ${TRANSLATION_API_HOST};
-            proxy_pass https://translation_api/$1;
-        }
+                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                    #
+				    # Tell client that this pre-flight info is valid for 20 days
+                    #
 
-        location ~* /translation/(.*) {
-            rewrite ^/translation/ /$1 break;
-            proxy_set_header Host ${TRANSLATION_API_HOST};
-            proxy_pass https://translation_api/$1;
-        }
+                    add_header 'Access-Control-Max-Age' 1728000;
+                    add_header 'Content-Type' 'text/plain; charset=utf-8';
+                    add_header 'Content-Length' 0;
+                    return 204;
+                }
+                if ($request_method = 'POST') {
+                    add_header 'Access-Control-Allow-Origin' '*' always;
+                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+                    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+                }
+                if ($request_method = 'GET') {
+                    add_header 'Access-Control-Allow-Origin' '*' always;
+                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+                    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+                }
+            }
 
-        # Newspaper search
-        location = /fulltext/search.json {
-            proxy_set_header Host ${NEWSPAPER_API_HOST};
-            proxy_pass http://newspaper_api/api/v2/search.json$is_args$args;
-        }
+            # ----------------------------------------------------------
 
-        location ~* ^/console/(record|iiif|annotation|thumbnail|ld|search|translation|entity|oai|set)$ {
-            return 307 https://$host/console/index.html?url=docs/v3/$1.json;
-        }
+            # Redirect root
+            location = / {
+                return 302 ${
+                    ROOT_REDIRECT_URL
+                };
+            }
 
-        # Old and deprecated (kept for the time being for backward compatibility)
-        # ----------------------------------------------------------
-        # Redirect old record url format (to be removed?)
-        #    Nov 2019 - again 0 hits in last 4 months
-        #    March 2020 - 0 hits at API, but I did notice that we have quite a bit of /resolve/record requests coming in via
-        #                 Portal, so for now I'm not removing entirely because I'm not sure if this means we want to put it back
-        #location ~ ^/resolve/record/(.*) {
-        #    return 301 https://$host/api/v2/record/$1$is_args$args;
-        #}
+            # Used by Kubernetes health checks
+            location /nginx-health {
+                default_type application/json;
+                return 200 '{"status":"healthy"}';
+            }
 
-        # Not sure why we have this rule and if it's still useful.
-        location ~ ^/api/(.*) {
-            rewrite ^/api/(.*)$ /api/$1 break;
-            proxy_set_header Host ${SEARCH_API_HOST};
-            proxy_pass http://search_api;
-        }
-      
-        # Redirect old thumbnail url format
-        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
-        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
-        location = /api/image {
-            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
-        }
-        
-        # Redirect old oai-pmh requests (added June 2019)
-        location = /oaicat/OAIHandler {
-            return 301 https://$host/oai/record$is_args$args;
-        }
-        
-        # Redirect old oai-pmh index form page (added June 2019)
-        location = /oaicat {
-            return 301 https://$host/oai/record/index.html;
-        }
-        
-        # Redirect old oai-pmh index form page (added June 2019)
-        location = /oaicat/ {
-            return 301 https://$host/oai/record/index.html;
-        }
-        
-        # Redirect all old oai-pmh forms (added June 2019)
-        location ~ ^/oaicat/(.*)\.(s)?html {
-            return 301 https://$host/oai/record/$1.html;
-        }
-        
-        # ----------------------------------------------------------
+            location ~* ^/test/(.*) {
+                return 200 '$1';
+            }
 
-        # Recommendation API (alternative path, has to be defined before Search & Record)
-        location ~ ^/record/(v2/)?(.*)/recommend {
-            proxy_set_header Host ${RECOMMENDATION_API_HOST};
-            proxy_pass http://recommendation_api/recommend/record/$2$is_args$args;
-        }
+            # no rewrite needed for proxying HOST requests
+            location ~* ^/translation/(translate|detect) {
+                proxy_set_header Host ${
+                    TRANSLATION_API_HOST
+                };
+                proxy_pass https://translation_api/$1;
+            }
 
-        # Search API
-        location ~ ^/record/(v2/)?(open)?search(.*) {
-            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
-            proxy_set_header Host ${SEARCH_API_HOST};
-            proxy_pass http://search_api;
-        }
+            location ~* /translation/(.*) {
+                rewrite ^/translation/ /$1 break;
+                proxy_set_header Host ${
+                    TRANSLATION_API_HOST
+                };
+                proxy_pass https://translation_api/$1;
+            }
 
-        # Record API
-        location ~ ^/record/(v2/)?(.*) {
-            rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
-            proxy_set_header Host ${SEARCH_API_HOST};
-            proxy_pass http://search_api;
-        }
+            # Newspaper search
+            location = /fulltext/search.json {
+                proxy_set_header Host ${
+                    NEWSPAPER_API_HOST
+                };
+                proxy_pass http://newspaper_api/api/v2/search.json$is_args$args;
+            }
 
-        # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)
-        location = /record/api-docs {
-            proxy_set_header Host ${SEARCH_API_HOST};
-            proxy_hide_header Access-Control-Allow-Origin;
-            add_header Access-Control-Allow-Origin "*";
-            proxy_pass http://search_api/api/api-docs;
-        }
 
-        # Thumbnail API v2 (old style)
-        location = /api/v2/thumbnail-by-url.json {
-            # Thumbnails are JPEGs; no need to gzip them
-            gzip off;
-            proxy_set_header Host ${THUMBNAIL_API_HOST};
-            proxy_pass http://thumbnail_api;
-        }
-        
-        # Thumbnail API v2 (new style)
-        location = /thumbnail/v2/url.json {
-            # Thumbnails are JPEGs; no need to gzip them
-            gzip off;
-            proxy_set_header Host ${THUMBNAIL_API_HOST};
-            proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json$is_args$args;
-        }
-        
-        location ~ /thumbnail/v2/(.*) {
-            # To make sure incorrect v2 requests are not sent to v3
-            return 404;
-        }
-        
-        # Thumbnail API v3
-        location ~ /thumbnail/(v3/)?(.*) {
-            # Thumbnails are JPEGs; no need to gzip them
-            gzip off;
-            proxy_set_header Host ${THUMBNAIL_API_HOST};
-            proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
-        }
+            location ~* ^/console/(record|iiif|annotation|thumbnail|ld|search|translation|entity|oai|set)$ {
+                return 307 https://$host/console/index.html?url=docs/v3/$1.json;
+            }
 
-        # OAI-PMH requests
-        location = /oai/record {
-            proxy_set_header Host ${OAI_RECORD_HOST};
-            proxy_pass http://oai_record/oai/$is_args$args;
-        }
-        
-        # OAI-PMH index page
-        location = /oai/record/ {
-            proxy_set_header Host ${OAI_RECORD_HOST};
-            proxy_pass http://oai_record/index.html;
-        }
-        
-        # Change all OAI-PMH .shtml form pages to .html
-        location ~ ^/oai/record/(.*)\.shtml {
-            return 301 https://$host/oai/record/$1.html;
-        }
-        
-        # OAI-PMH query forms
-        location ~ ^/oai/record/(.*)\.html {
-            proxy_set_header Host ${OAI_RECORD_HOST};
-            proxy_pass http://oai_record/$1.html;
-        }
+            # Old and deprecated (kept for the time being for backward compatibility)
+            # ----------------------------------------------------------
+            # Redirect old record url format (to be removed?)
+            #    Nov 2019 - again 0 hits in last 4 months
+            #    March 2020 - 0 hits at API, but I did notice that we have quite a bit of /resolve/record requests coming in via
+            #                 Portal, so for now I'm not removing entirely because I'm not sure if this means we want to put it back
+            #location ~ ^/resolve/record/(.*) {
+            #    return 301 https://$host/api/v2/record/$1$is_args$args;
+            #}
 
-        # Annotation API
-        location ~ ^/annotation/(.*) {
-            proxy_set_header Host ${ANNOTATION_API_HOST};
-            proxy_pass http://annotation_api/annotation/$1$is_args$args;
-        }
+            # Not sure why we have this rule and if it's still useful.
+            location ~ ^/api/(.*) {
+                rewrite ^/api/(.*)$ /api/$1 break;
+                proxy_set_header Host ${
+                    SEARCH_API_HOST
+                };
+                proxy_pass http://search_api;
+            }
 
-        # Entity - search, resolve and suggest are routed to Entity API
-        location ~ ^/entity/(search|suggest|resolve|enrich|stats)(.*) {
-            proxy_set_header Host ${ENTITY_API_HOST};
-            proxy_pass http://entity_api/entity/$1$2$is_args$args;
-        }
+            # Redirect old thumbnail url format
+            #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
+            #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
+            location = /api/image {
+                return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
+            }
 
-        # Entity - all other requests go to Entity Management
-        location ~ ^/entity/(.*) {
-            proxy_set_header Host ${ENTITY_MANAGEMENT_HOST};
-            proxy_pass http://entity_management/entity/$1$is_args$args;
-        }
+            # Redirect old oai-pmh requests (added June 2019)
+            location = /oaicat/OAIHandler {
+                return 301 https://$host/oai/record$is_args$args;
+            }
 
-        # Manifest API
-        location ~ ^/presentation/(.*)/manifest$ {
-            proxy_set_header Host ${MANIFEST_API_HOST};
-            proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
-        }
+            # Redirect old oai-pmh index form page (added June 2019)
+            location = /oaicat {
+                return 301 https://$host/oai/record/index.html;
+            }
 
-        # Fulltext API
-        location ~ ^/(fulltext|presentation)/(.*) {
-            proxy_set_header Host ${FULLTEXT_API_HOST};
-            proxy_pass http://fulltext_api/presentation/$2$is_args$args;
-        }
+            # Redirect old oai-pmh index form page (added June 2019)
+            location = /oaicat/ {
+                return 301 https://$host/oai/record/index.html;
+            }
 
-        # Recommendation API
-        location ~ ^/recommend/(.*) {
-            proxy_set_header Host ${RECOMMENDATION_API_HOST};
-            proxy_pass http://recommendation_api/recommend/$1$is_args$args;
-        }
+            # Redirect all old oai-pmh forms (added June 2019)
+            location ~ ^/oaicat/(.*)\.(s)?html {
+                return 301 https://$host/oai/record/$1.html;
+            }
 
-        # Recommendation API (alternative path)
-        location ~ ^/set/(.*)/recommend {
-            proxy_set_header Host ${RECOMMENDATION_API_HOST};
-            proxy_pass http://recommendation_api/recommend/set/$1$is_args$args;
-        }
+            # ----------------------------------------------------------
 
-        # Sets API
-        location ~ ^/set/(.*) {
-            proxy_set_header Host ${SET_API_HOST};
-            proxy_pass http://set_api/set/$1$is_args$args;
-        }
-        
-        # ----------------------------------------------------------
+            # Recommendation API (alternative path, has to be defined before Search & Record)
+            location ~ ^/record/(v2/)?(.*)/recommend {
+                proxy_set_header Host ${
+                    RECOMMENDATION_API_HOST
+                };
+                proxy_pass http://recommendation_api/recommend/record/$2$is_args$args;
+            }
 
-        # Set CORS Headers for attribution snippet's CSS & font requests
-        location ~ ^/attribution/(.*) {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+            # Search API
+            location ~ ^/record/(v2/)?(open)?search(.*) {
+                rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
+                proxy_set_header Host ${
+                    SEARCH_API_HOST
+                };
+                proxy_pass http://search_api;
+            }
+
+            # Record API
+            location ~ ^/record/(v2/)?(.*) {
+                rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
+                proxy_set_header Host ${
+                    SEARCH_API_HOST
+                };
+                proxy_pass http://search_api;
+            }
+
+            # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)
+            location = /record/api-docs {
+                proxy_set_header Host ${
+                    SEARCH_API_HOST
+                };
+                proxy_hide_header Access-Control-Allow-Origin;
+                add_header Access-Control-Allow-Origin "*";
+                proxy_pass http://search_api/api/api-docs;
+            }
+
+            # Thumbnail API v2 (old style)
+            location = /api/v2/thumbnail-by-url.json {
+                # Thumbnails are JPEGs; no need to gzip them
+                gzip off;
+                proxy_set_header Host ${
+                    THUMBNAIL_API_HOST
+                };
+                proxy_pass http://thumbnail_api;
+            }
+
+            # Thumbnail API v2 (new style)
+            location = /thumbnail/v2/url.json {
+                # Thumbnails are JPEGs; no need to gzip them
+                gzip off;
+                proxy_set_header Host ${
+                    THUMBNAIL_API_HOST
+                };
+                proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json$is_args$args;
+            }
+
+            location ~ /thumbnail/v2/(.*) {
+                # To make sure incorrect v2 requests are not sent to v3
+                return 404;
+            }
+
+            # Thumbnail API v3
+            location ~ /thumbnail/(v3/)?(.*) {
+                # Thumbnails are JPEGs; no need to gzip them
+                gzip off;
+                proxy_set_header Host ${
+                    THUMBNAIL_API_HOST
+                };
+                proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
+            }
+
+            # OAI-PMH requests
+            location = /oai/record {
+                proxy_set_header Host ${
+                    OAI_RECORD_HOST
+                };
+                proxy_pass http://oai_record/oai/$is_args$args;
+            }
+
+            # OAI-PMH index page
+            location = /oai/record/ {
+                proxy_set_header Host ${
+                    OAI_RECORD_HOST
+                };
+                proxy_pass http://oai_record/index.html;
+            }
+
+            # Change all OAI-PMH .shtml form pages to .html
+            location ~ ^/oai/record/(.*)\.shtml {
+                return 301 https://$host/oai/record/$1.html;
+            }
+
+            # OAI-PMH query forms
+            location ~ ^/oai/record/(.*)\.html {
+                proxy_set_header Host ${
+                    OAI_RECORD_HOST
+                };
+                proxy_pass http://oai_record/$1.html;
+            }
+
+            # Annotation API
+            location ~ ^/annotation/(.*) {
+                proxy_set_header Host ${
+                    ANNOTATION_API_HOST
+                };
+                proxy_pass http://annotation_api/annotation/$1$is_args$args;
+            }
+
+            # Entity - search, resolve and suggest are routed to Entity API
+            location ~ ^/entity/(search|suggest|resolve|enrich|stats)(.*) {
+                proxy_set_header Host ${
+                    ENTITY_API_HOST
+                };
+                proxy_pass http://entity_api/entity/$1$2$is_args$args;
+            }
+
+            # Entity - all other requests go to Entity Management
+            location ~ ^/entity/(.*) {
+                proxy_set_header Host ${
+                    ENTITY_MANAGEMENT_HOST
+                };
+                proxy_pass http://entity_management/entity/$1$is_args$args;
+            }
+
+            # Manifest API
+            location ~ ^/presentation/(.*)/manifest$ {
+                proxy_set_header Host ${
+                    MANIFEST_API_HOST
+                };
+                proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
+            }
+
+            # Fulltext API
+            location ~ ^/(fulltext|presentation)/(.*) {
+                proxy_set_header Host ${
+                    FULLTEXT_API_HOST
+                };
+                proxy_pass http://fulltext_api/presentation/$2$is_args$args;
+            }
+
+            # Recommendation API
+            location ~ ^/recommend/(.*) {
+                proxy_set_header Host ${
+                    RECOMMENDATION_API_HOST
+                };
+                proxy_pass http://recommendation_api/recommend/$1$is_args$args;
+            }
+
+            # Recommendation API (alternative path)
+            location ~ ^/set/(.*)/recommend {
+                proxy_set_header Host ${
+                    RECOMMENDATION_API_HOST
+                };
+                proxy_pass http://recommendation_api/recommend/set/$1$is_args$args;
+            }
+
+            # Sets API
+            location ~ ^/set/(.*) {
+                proxy_set_header Host ${
+                    SET_API_HOST
+                };
+                proxy_pass http://set_api/set/$1$is_args$args;
+            }
         }
     }
-}

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -84,7 +84,7 @@ http {
 
 
     server {
-        listen 80 default_server;
+        listen 443 default_server;
 #         server_name ${API_GATEWAY_HOST};
 #         return 308 https://$host$request_uri;
 #     }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -114,6 +114,17 @@ http {
             proxy_pass http://translation_api/$1;
         }
 
+        # possible fix 
+#         location /translation {
+#             proxy_set_header Authorization $http_authorization;
+#             proxy_pass_header Authorization;
+#             proxy_set_header Host $proxy_host;
+#             proxy_ssl_server_name on;
+#
+# #             proxy_pass https://$http_x_forwarded_to;
+#             proxy_pass https://translation_api;
+#         }
+
         # Newspaper search
         location = /fulltext/search.json {
             proxy_set_header Host ${NEWSPAPER_API_HOST};

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -82,11 +82,6 @@ http {
         server ${NEWSPAPER_API_HOST};
     }
 
-    upstream keycloak {
-        keepalive 10;
-        server ${KEYCLOAK_HOST}:443;
-    }
-
 
     server {
         listen 80 default_server;
@@ -101,274 +96,229 @@ http {
 
         include nginx.conf.d/*.conf;
 
-            # ----------------------------------------------------------
-            #
-		    # Wide-open CORS config for nginx
-            #
-            # ----------------------------------------------------------
-            location / {
-                if ($request_method = 'OPTIONS') {
-                    add_header 'Access-Control-Allow-Origin' '*';
-                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                    #
-				    # Custom headers and headers various browsers *should* be OK with but aren't
-                    #
+        # Redirect root
+        location = / {
+            return 302 ${ROOT_REDIRECT_URL};
+        }
 
-                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                    #
-				    # Tell client that this pre-flight info is valid for 20 days
-                    #
+        # Used by Kubernetes health checks
+        location /nginx-health {
+            default_type application/json;
+            return 200 '{"status":"healthy"}';
+        }
 
-                    add_header 'Access-Control-Max-Age' 1728000;
-                    add_header 'Content-Type' 'text/plain; charset=utf-8';
-                    add_header 'Content-Length' 0;
-                    return 204;
-                }
-                if ($request_method = 'POST') {
-                    add_header 'Access-Control-Allow-Origin' '*' always;
-                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
-                    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
-                }
-                if ($request_method = 'GET') {
-                    add_header 'Access-Control-Allow-Origin' '*' always;
-                    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
-                    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
-                }
-            }
+        location ~* ^/test/(.*) {
+            return 200 '$1';
+        }
 
-            # ----------------------------------------------------------
-
-            # Redirect root
-            location = / {
-                return 302 ${ROOT_REDIRECT_URL};
-            }
-
-            # Used by Kubernetes health checks
-            location /nginx-health {
-                default_type application/json;
-                return 200 '{"status":"healthy"}';
-            }
-
-            location ~* ^/test/(.*) {
-                return 200 '$1';
-            }
-
-            # no rewrite needed for proxying HOST requests
-            location ~* ^/translation/(translate|detect) {
-                proxy_set_header Host ${TRANSLATION_API_HOST};
-                proxy_pass https://translation_api/$1;
-            }
+        # no rewrite needed for proxying HOST requests
+        location ~* ^/translation/(translate|detect) {
+            proxy_set_header Host ${TRANSLATION_API_HOST};
+            proxy_pass https://translation_api/$1;
+        }
 
 
-            # Tightened this one up to stop the weird redirection to the broken Swagger url in the index.html of the translation API
-            location /translation/actuator/info {
-                rewrite ^/translation/ /actuator/info break;
-                proxy_set_header Host ${TRANSLATION_API_HOST};
-                proxy_pass https://translation_api;
-            }
+        # Tightened this one up to stop the weird redirection to the broken Swagger url in the index.html of the translation API
+        location /translation/actuator/info {
+            rewrite ^/translation/ /actuator/info break;
+            proxy_set_header Host ${TRANSLATION_API_HOST};
+            proxy_pass https://translation_api;
+        }
 
-            # Newspaper search
-            location = /fulltext/search.json {
-                proxy_set_header Host ${NEWSPAPER_API_HOST};
-                proxy_pass http://newspaper_api/api/v2/search.json$is_args$args;
-            }
-
-
-            location ~* ^/console/(record|iiif|annotation|thumbnail|ld|search|translation|entity|oai|set)$ {
-                return 307 https://$host/console/index.html?url=docs/v3/$1.json;
-            }
-
-            # Old and deprecated (kept for the time being for backward compatibility)
-            # ----------------------------------------------------------
-            # Redirect old record url format (to be removed?)
-            #    Nov 2019 - again 0 hits in last 4 months
-            #    March 2020 - 0 hits at API, but I did notice that we have quite a bit of /resolve/record requests coming in via
-            #                 Portal, so for now I'm not removing entirely because I'm not sure if this means we want to put it back
-            #location ~ ^/resolve/record/(.*) {
-            #    return 301 https://$host/api/v2/record/$1$is_args$args;
-            #}
-
-            # Not sure why we have this rule and if it's still useful.
-            location ~ ^/api/(.*) {
-                rewrite ^/api/(.*)$ /api/$1 break;
-                proxy_set_header Host ${SEARCH_API_HOST};
-                proxy_pass http://search_api;
-            }
-
-            # Redirect old thumbnail url format
-            #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
-            #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
-            location = /api/image {
-                return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
-            }
-
-            # Redirect old oai-pmh requests (added June 2019)
-            location = /oaicat/OAIHandler {
-                return 301 https://$host/oai/record$is_args$args;
-            }
-
-            # Redirect old oai-pmh index form page (added June 2019)
-            location = /oaicat {
-                return 301 https://$host/oai/record/index.html;
-            }
-
-            # Redirect old oai-pmh index form page (added June 2019)
-            location = /oaicat/ {
-                return 301 https://$host/oai/record/index.html;
-            }
-
-            # Redirect all old oai-pmh forms (added June 2019)
-            location ~ ^/oaicat/(.*)\.(s)?html {
-                return 301 https://$host/oai/record/$1.html;
-            }
+        # Newspaper search
+        location = /fulltext/search.json {
+            proxy_set_header Host ${NEWSPAPER_API_HOST};
+            proxy_pass http://newspaper_api/api/v2/search.json$is_args$args;
+        }
 
 
-            # ----------------------------------------------------------
+        location ~* ^/console/(record|iiif|annotation|thumbnail|ld|search|translation|entity|oai|set)$ {
+            return 307 https://$host/console/index.html?url=docs/v3/$1.json;
+        }
+
+        # Old and deprecated (kept for the time being for backward compatibility)
+        # ----------------------------------------------------------
+        # Redirect old record url format (to be removed?)
+        #    Nov 2019 - again 0 hits in last 4 months
+        #    March 2020 - 0 hits at API, but I did notice that we have quite a bit of /resolve/record requests coming in via
+        #                 Portal, so for now I'm not removing entirely because I'm not sure if this means we want to put it back
+        #location ~ ^/resolve/record/(.*) {
+        #    return 301 https://$host/api/v2/record/$1$is_args$args;
+        #}
+
+        # Not sure why we have this rule and if it's still useful.
+        location ~ ^/api/(.*) {
+            rewrite ^/api/(.*)$ /api/$1 break;
+            proxy_set_header Host ${SEARCH_API_HOST};
+            proxy_pass http://search_api;
+        }
+
+        # Redirect old thumbnail url format
+        #    Feb 2019 - about 1000 requests a month are still done directly to api (and all of them fail with 500 or 404)
+        #    Nov 2019 - still about 1000 requests per month, most return 500 or 404, a few return 301
+        location = /api/image {
+            return 301 https://$host/api/v2/thumbnail-by-url.json$is_args$args;
+        }
+
+        # Redirect old oai-pmh requests (added June 2019)
+        location = /oaicat/OAIHandler {
+            return 301 https://$host/oai/record$is_args$args;
+        }
+
+        # Redirect old oai-pmh index form page (added June 2019)
+        location = /oaicat {
+            return 301 https://$host/oai/record/index.html;
+        }
+
+        # Redirect old oai-pmh index form page (added June 2019)
+        location = /oaicat/ {
+            return 301 https://$host/oai/record/index.html;
+        }
+
+        # Redirect all old oai-pmh forms (added June 2019)
+        location ~ ^/oaicat/(.*)\.(s)?html {
+            return 301 https://$host/oai/record/$1.html;
+        }
 
 
-            # EA-3761
-#             location ~ ^/(auth)/?(protocol/openid-connect|account)?(.*)? {
-#                 set $authPath $1/realms/europeana/$2$3;
-#                 proxy_set_header Host ${KEYCLOAK_HOST};
-#                 add_header 'X-Wickie' "$authPath" always;
-#                 proxy_pass https://keycloak/$authPath;
-#             }
+        # ----------------------------------------------------------
 
-            location ~ ^/(auth)(/realms/europeana)(/protocol/openid-connect|/account)?(.*)? {
-                set $authPath $1/realms/europeana/$3$4;
-                proxy_set_header Host ${KEYCLOAK_HOST};
-                add_header 'X-Wickie' "$authPath" always;
-                proxy_pass https://keycloak/$authPath;
-            }
+        # Recommendation API (alternative path, has to be defined before Search & Record)
+        location ~ ^/record/(v2/)?(.*)/recommend {
+            proxy_set_header Host ${RECOMMENDATION_API_HOST};
+            proxy_pass http://recommendation_api/recommend/record/$2$is_args$args;
+        }
 
-            # Recommendation API (alternative path, has to be defined before Search & Record)
-            location ~ ^/record/(v2/)?(.*)/recommend {
-                proxy_set_header Host ${RECOMMENDATION_API_HOST};
-                proxy_pass http://recommendation_api/recommend/record/$2$is_args$args;
-            }
+        # Search API
+        location ~ ^/record/(v2/)?(open)?search(.*) {
+            rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
+            proxy_set_header Host ${SEARCH_API_HOST};
+            proxy_pass http://search_api;
+        }
 
-            # Search API
-            location ~ ^/record/(v2/)?(open)?search(.*) {
-                rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
-                proxy_set_header Host ${SEARCH_API_HOST};
-                proxy_pass http://search_api;
-            }
+        # Record API
+        location ~ ^/record/(v2/)?(.*) {
+            rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
+            proxy_set_header Host ${SEARCH_API_HOST};
+            proxy_pass http://search_api;
+        }
 
-            # Record API
-            location ~ ^/record/(v2/)?(.*) {
-                rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
-                proxy_set_header Host ${SEARCH_API_HOST};
-                proxy_pass http://search_api;
-            }
+        # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)
+        location = /record/api-docs {
+            proxy_set_header Host ${SEARCH_API_HOST};
+            proxy_hide_header Access-Control-Allow-Origin;
+            add_header Access-Control-Allow-Origin "*";
+            proxy_pass http://search_api/api/api-docs;
+        }
 
-            # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)
-            location = /record/api-docs {
-                proxy_set_header Host ${SEARCH_API_HOST};
-                proxy_hide_header Access-Control-Allow-Origin;
-                add_header Access-Control-Allow-Origin "*";
-                proxy_pass http://search_api/api/api-docs;
-            }
+        # Thumbnail API v2 (old style)
+        location = /api/v2/thumbnail-by-url.json {
+            # Thumbnails are JPEGs; no need to gzip them
+            gzip off;
+            proxy_set_header Host ${THUMBNAIL_API_HOST};
+            proxy_pass http://thumbnail_api;
+        }
 
-            # Thumbnail API v2 (old style)
-            location = /api/v2/thumbnail-by-url.json {
-                # Thumbnails are JPEGs; no need to gzip them
-                gzip off;
-                proxy_set_header Host ${THUMBNAIL_API_HOST};
-                proxy_pass http://thumbnail_api;
-            }
+        # Thumbnail API v2 (new style)
+        location = /thumbnail/v2/url.json {
+            # Thumbnails are JPEGs; no need to gzip them
+            gzip off;
+            proxy_set_header Host ${THUMBNAIL_API_HOST};
+            proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json$is_args$args;
+        }
 
-            # Thumbnail API v2 (new style)
-            location = /thumbnail/v2/url.json {
-                # Thumbnails are JPEGs; no need to gzip them
-                gzip off;
-                proxy_set_header Host ${THUMBNAIL_API_HOST};
-                proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json$is_args$args;
-            }
+        location ~ /thumbnail/v2/(.*) {
+            # To make sure incorrect v2 requests are not sent to v3
+            return 404;
+        }
 
-            location ~ /thumbnail/v2/(.*) {
-                # To make sure incorrect v2 requests are not sent to v3
-                return 404;
-            }
+        # Thumbnail API v3
+        location ~ /thumbnail/(v3/)?(.*) {
+            # Thumbnails are JPEGs; no need to gzip them
+            gzip off;
+            proxy_set_header Host ${THUMBNAIL_API_HOST};
+            proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
+        }
 
-            # Thumbnail API v3
-            location ~ /thumbnail/(v3/)?(.*) {
-                # Thumbnails are JPEGs; no need to gzip them
-                gzip off;
-                proxy_set_header Host ${THUMBNAIL_API_HOST};
-                proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
-            }
+        # OAI-PMH requests
+        location = /oai/record {
+            proxy_set_header Host ${OAI_RECORD_HOST};
+            proxy_pass http://oai_record/oai/$is_args$args;
+        }
 
-            # OAI-PMH requests
-            location = /oai/record {
-                proxy_set_header Host ${OAI_RECORD_HOST};
-                proxy_pass http://oai_record/oai/$is_args$args;
-            }
+        # OAI-PMH index page
+        location = /oai/record/ {
+            proxy_set_header Host ${OAI_RECORD_HOST};
+            proxy_pass http://oai_record/index.html;
+        }
 
-            # OAI-PMH index page
-            location = /oai/record/ {
-                proxy_set_header Host ${OAI_RECORD_HOST};
-                proxy_pass http://oai_record/index.html;
-            }
+        # Change all OAI-PMH .shtml form pages to .html
+        location ~ ^/oai/record/(.*)\.shtml {
+            return 301 https://$host/oai/record/$1.html;
+        }
 
-            # Change all OAI-PMH .shtml form pages to .html
-            location ~ ^/oai/record/(.*)\.shtml {
-                return 301 https://$host/oai/record/$1.html;
-            }
+        # OAI-PMH query forms
+        location ~ ^/oai/record/(.*)\.html {
+            proxy_set_header Host ${OAI_RECORD_HOST};
+            proxy_pass http://oai_record/$1.html;
+        }
 
-            # OAI-PMH query forms
-            location ~ ^/oai/record/(.*)\.html {
-                proxy_set_header Host ${OAI_RECORD_HOST};
-                proxy_pass http://oai_record/$1.html;
-            }
+        # Annotation API
+        location ~ ^/annotation/(.*) {
+            proxy_set_header Host ${ANNOTATION_API_HOST};
+            proxy_pass http://annotation_api/annotation/$1$is_args$args;
+        }
 
-            # Annotation API
-            location ~ ^/annotation/(.*) {
-                proxy_set_header Host $ANNOTATION_API_HOST};
-                proxy_pass http://annotation_api/annotation/$1$is_args$args;
-            }
+        # Entity - search, resolve and suggest are routed to Entity API
+        location ~ ^/entity/(search|suggest|resolve|enrich|stats)(.*) {
+            proxy_set_header Host ${ENTITY_API_HOST};
+            proxy_pass http://entity_api/entity/$1$2$is_args$args;
+        }
 
-            # Entity - search, resolve and suggest are routed to Entity API
-            location ~ ^/entity/(search|suggest|resolve|enrich|stats)(.*) {
-                proxy_set_header Host ${ENTITY_API_HOST};
-                proxy_pass http://entity_api/entity/$1$2$is_args$args;
-            }
+        # Entity - all other requests go to Entity Management
+        location ~ ^/entity/(.*) {
+            proxy_set_header Host ${ENTITY_MANAGEMENT_HOST};
+            proxy_pass http://entity_management/entity/$1$is_args$args;
+        }
 
-            # Entity - all other requests go to Entity Management
-            location ~ ^/entity/(.*) {
-                proxy_set_header Host ${ENTITY_MANAGEMENT_HOST};
-                proxy_pass http://entity_management/entity/$1$is_args$args;
-            }
+        # Manifest API
+        location ~ ^/presentation/(.*)/manifest$ {
+            proxy_set_header Host ${MANIFEST_API_HOST};
+            proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
+        }
 
-            # Manifest API
-            location ~ ^/presentation/(.*)/manifest$ {
-                proxy_set_header Host ${MANIFEST_API_HOST};
-                proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
-            }
+        # Fulltext API
+        location ~ ^/(fulltext|presentation)/(.*) {
+            proxy_set_header Host ${FULLTEXT_API_HOST};
+            proxy_pass http://fulltext_api/presentation/$2$is_args$args;
+        }
 
-            # Fulltext API
-            location ~ ^/(fulltext|presentation)/(.*) {
-                proxy_set_header Host ${FULLTEXT_API_HOST};
-                proxy_pass http://fulltext_api/presentation/$2$is_args$args;
-            }
+        # Recommendation API
+        location ~ ^/recommend/(.*) {
+            proxy_set_header Host ${RECOMMENDATION_API_HOST};
+            proxy_pass http://recommendation_api/recommend/$1$is_args$args;
+        }
 
-            # Recommendation API
-            location ~ ^/recommend/(.*) {
-                proxy_set_header Host ${RECOMMENDATION_API_HOST};
-                proxy_pass http://recommendation_api/recommend/$1$is_args$args;
-            }
+        # Recommendation API (alternative path)
+        location ~ ^/set/(.*)/recommend {
+            proxy_set_header Host ${RECOMMENDATION_API_HOST};
+            proxy_pass http://recommendation_api/recommend/set/$1$is_args$args;
+        }
 
-            # Recommendation API (alternative path)
-            location ~ ^/set/(.*)/recommend {
-                proxy_set_header Host ${RECOMMENDATION_API_HOST};
-                proxy_pass http://recommendation_api/recommend/set/$1$is_args$args;
-            }
+        # Sets API
+        location ~ ^/set/(.*) {
+            proxy_set_header Host ${SET_API_HOST};
+            proxy_pass http://set_api/set/$1$is_args$args;
+        }
 
-            # Sets API
-            location ~ ^/set/(.*) {
-                proxy_set_header Host ${SET_API_HOST};
-                proxy_pass http://set_api/set/$1$is_args$args;
-            }
+        # ----------------------------------------------------------
+
+        # Set CORS Headers for attribution snippet's CSS & font requests
+        location ~ ^/attribution/(.*) {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
         }
     }
+}

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -84,12 +84,20 @@ http {
 
 
     server {
-        listen 80;
+        listen 80 default_server;
+#         server_name ${API_GATEWAY_HOST};
+        return 308 https://$host$request_uri;
+    }
+
+
+    server {
+        listen 443 default_server;
+#         server_name ${API_GATEWAY_HOST};
         root /usr/share/nginx/html;
         index index.html;
 
         # HTTPS enforcement should be done within Kubernetes ingress
-
+        # so I have some doubts if the above 308 redirection is fully OK?
         # "upstream" servers do not use resolver settings by default (paid option), so we proxy directly to the urls
         #resolver ${RESOLVER_SETTINGS};
 

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -86,12 +86,12 @@ http {
     server {
         listen 80 default_server;
 #         server_name ${API_GATEWAY_HOST};
-        return 308 https://$host$request_uri;
-    }
+#         return 308 https://$host$request_uri;
+#     }
 
 
-    server {
-        listen 443 default_server;
+#     server {
+#         listen 443 default_server;
 #         server_name ${API_GATEWAY_HOST};
         root /usr/share/nginx/html;
         index index.html;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -161,6 +161,7 @@ http {
                 proxy_pass https://translation_api/$1;
             }
 
+
             # Tightened this one up to stop the weird redirection to the broken Swagger url in the index.html of the translation API
             location /translation/actuator/info {
                 rewrite ^/translation/ /actuator/info break;
@@ -241,13 +242,6 @@ http {
                 add_header 'X-Wickie' "$authPath" always;
                 proxy_pass https://keycloak/$authPath;
             }
-
-            location ~* /translation/(.*) {
-                rewrite ^/translation/ /$1 break;
-                proxy_set_header Host ${TRANSLATION_API_HOST};
-                proxy_pass https://translation_api/$1;
-            }
-
 
             # Recommendation API (alternative path, has to be defined before Search & Record)
             location ~ ^/record/(v2/)?(.*)/recommend {

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -108,6 +108,10 @@ http {
             return 200 '{"status":"healthy"}';
         }
 
+        location ~* ^/test/(.*) {
+            return 200 '$1';
+        }
+
         # no rewrite needed for proxying HOST requests
         location ~* ^/translation/(translate|detect) {
             proxy_set_header Host ${TRANSLATION_API_HOST};

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -24,87 +24,62 @@ http {
     # Note that for upstream servers all IP addresses/services need to be available on start-up!
     upstream annotation_api {
         keepalive 10;
-        server ${
-            ANNOTATION_API_HOST
-        };
+        server ${ANNOTATION_API_HOST};
     }
 
     upstream entity_api {
         keepalive 10;
-        server ${
-            ENTITY_API_HOST
-        };
+        server ${ENTITY_API_HOST};
     }
 
     upstream entity_management {
         keepalive 10;
-        server ${
-            ENTITY_MANAGEMENT_HOST
-        };
+        server ${ENTITY_MANAGEMENT_HOST};
     }
 
     upstream fulltext_api {
         keepalive 10;
-        server ${
-            FULLTEXT_API_HOST
-        };
+        server ${FULLTEXT_API_HOST};
     }
 
     upstream manifest_api {
         keepalive 10;
-        server ${
-            MANIFEST_API_HOST
-        };
+        server ${MANIFEST_API_HOST};
     }
 
     upstream oai_record {
         keepalive 10;
-        server ${
-            OAI_RECORD_HOST
-        };
+        server ${OAI_RECORD_HOST};
     }
 
     upstream recommendation_api {
         keepalive 10;
-        server ${
-            RECOMMENDATION_API_HOST
-        };
+        server ${RECOMMENDATION_API_HOST};
     }
 
     upstream search_api {
         keepalive 10;
-        server ${
-            SEARCH_API_HOST
-        };
+        server ${SEARCH_API_HOST};
     }
 
     upstream set_api {
         keepalive 10;
-        server ${
-            SET_API_HOST
-        };
+        server ${SET_API_HOST};
     }
 
     upstream thumbnail_api {
         keepalive 10;
-        server ${
-            THUMBNAIL_API_HOST
-        };
+        server ${THUMBNAIL_API_HOST};
     }
 
     upstream translation_api {
         keepalive 10;
-        server ${
-            TRANSLATION_API_HOST
-        }
-        :443;
+        server ${TRANSLATION_API_HOST}:443;
     }
 
     upstream newspaper_api {
         keepalive 10;
-        server ${
-            NEWSPAPER_API_HOST
-        };
+        server ${NEWSPAPER_API_HOST};
     }
 
 
@@ -162,9 +137,7 @@ http {
 
             # Redirect root
             location = / {
-                return 302 ${
-                    ROOT_REDIRECT_URL
-                };
+                return 302 ${ROOT_REDIRECT_URL};
             }
 
             # Used by Kubernetes health checks
@@ -179,25 +152,19 @@ http {
 
             # no rewrite needed for proxying HOST requests
             location ~* ^/translation/(translate|detect) {
-                proxy_set_header Host ${
-                    TRANSLATION_API_HOST
-                };
+                proxy_set_header Host ${TRANSLATION_API_HOST};
                 proxy_pass https://translation_api/$1;
             }
 
             location ~* /translation/(.*) {
                 rewrite ^/translation/ /$1 break;
-                proxy_set_header Host ${
-                    TRANSLATION_API_HOST
-                };
+                proxy_set_header Host ${TRANSLATION_API_HOST};
                 proxy_pass https://translation_api/$1;
             }
 
             # Newspaper search
             location = /fulltext/search.json {
-                proxy_set_header Host ${
-                    NEWSPAPER_API_HOST
-                };
+                proxy_set_header Host ${NEWSPAPER_API_HOST};
                 proxy_pass http://newspaper_api/api/v2/search.json$is_args$args;
             }
 
@@ -219,9 +186,7 @@ http {
             # Not sure why we have this rule and if it's still useful.
             location ~ ^/api/(.*) {
                 rewrite ^/api/(.*)$ /api/$1 break;
-                proxy_set_header Host ${
-                    SEARCH_API_HOST
-                };
+                proxy_set_header Host ${SEARCH_API_HOST};
                 proxy_pass http://search_api;
             }
 
@@ -256,35 +221,27 @@ http {
 
             # Recommendation API (alternative path, has to be defined before Search & Record)
             location ~ ^/record/(v2/)?(.*)/recommend {
-                proxy_set_header Host ${
-                    RECOMMENDATION_API_HOST
-                };
+                proxy_set_header Host ${RECOMMENDATION_API_HOST};
                 proxy_pass http://recommendation_api/recommend/record/$2$is_args$args;
             }
 
             # Search API
             location ~ ^/record/(v2/)?(open)?search(.*) {
                 rewrite ^/record/(v2/)?(open)?search(.*)$ /api/v2/$2search$3 break;
-                proxy_set_header Host ${
-                    SEARCH_API_HOST
-                };
+                proxy_set_header Host ${SEARCH_API_HOST};
                 proxy_pass http://search_api;
             }
 
             # Record API
             location ~ ^/record/(v2/)?(.*) {
                 rewrite  ^/record/(v2/)?(.*)$ /api/v2/record/$2 break;
-                proxy_set_header Host ${
-                    SEARCH_API_HOST
-                };
+                proxy_set_header Host ${SEARCH_API_HOST};
                 proxy_pass http://search_api;
             }
 
             # Always enable CORS for Search & Record API Swagger endpoint (as bug fix)
             location = /record/api-docs {
-                proxy_set_header Host ${
-                    SEARCH_API_HOST
-                };
+                proxy_set_header Host ${SEARCH_API_HOST};
                 proxy_hide_header Access-Control-Allow-Origin;
                 add_header Access-Control-Allow-Origin "*";
                 proxy_pass http://search_api/api/api-docs;
@@ -294,9 +251,7 @@ http {
             location = /api/v2/thumbnail-by-url.json {
                 # Thumbnails are JPEGs; no need to gzip them
                 gzip off;
-                proxy_set_header Host ${
-                    THUMBNAIL_API_HOST
-                };
+                proxy_set_header Host ${THUMBNAIL_API_HOST};
                 proxy_pass http://thumbnail_api;
             }
 
@@ -304,9 +259,7 @@ http {
             location = /thumbnail/v2/url.json {
                 # Thumbnails are JPEGs; no need to gzip them
                 gzip off;
-                proxy_set_header Host ${
-                    THUMBNAIL_API_HOST
-                };
+                proxy_set_header Host ${THUMBNAIL_API_HOST};
                 proxy_pass http://thumbnail_api/api/v2/thumbnail-by-url.json$is_args$args;
             }
 
@@ -319,25 +272,19 @@ http {
             location ~ /thumbnail/(v3/)?(.*) {
                 # Thumbnails are JPEGs; no need to gzip them
                 gzip off;
-                proxy_set_header Host ${
-                    THUMBNAIL_API_HOST
-                };
+                proxy_set_header Host ${THUMBNAIL_API_HOST};
                 proxy_pass http://thumbnail_api/thumbnail/v3/$2$is_args$args;
             }
 
             # OAI-PMH requests
             location = /oai/record {
-                proxy_set_header Host ${
-                    OAI_RECORD_HOST
-                };
+                proxy_set_header Host ${OAI_RECORD_HOST};
                 proxy_pass http://oai_record/oai/$is_args$args;
             }
 
             # OAI-PMH index page
             location = /oai/record/ {
-                proxy_set_header Host ${
-                    OAI_RECORD_HOST
-                };
+                proxy_set_header Host ${OAI_RECORD_HOST};
                 proxy_pass http://oai_record/index.html;
             }
 
@@ -348,73 +295,55 @@ http {
 
             # OAI-PMH query forms
             location ~ ^/oai/record/(.*)\.html {
-                proxy_set_header Host ${
-                    OAI_RECORD_HOST
-                };
+                proxy_set_header Host ${OAI_RECORD_HOST};
                 proxy_pass http://oai_record/$1.html;
             }
 
             # Annotation API
             location ~ ^/annotation/(.*) {
-                proxy_set_header Host ${
-                    ANNOTATION_API_HOST
-                };
+                proxy_set_header Host $ANNOTATION_API_HOST};
                 proxy_pass http://annotation_api/annotation/$1$is_args$args;
             }
 
             # Entity - search, resolve and suggest are routed to Entity API
             location ~ ^/entity/(search|suggest|resolve|enrich|stats)(.*) {
-                proxy_set_header Host ${
-                    ENTITY_API_HOST
-                };
+                proxy_set_header Host ${ENTITY_API_HOST};
                 proxy_pass http://entity_api/entity/$1$2$is_args$args;
             }
 
             # Entity - all other requests go to Entity Management
             location ~ ^/entity/(.*) {
-                proxy_set_header Host ${
-                    ENTITY_MANAGEMENT_HOST
-                };
+                proxy_set_header Host ${ENTITY_MANAGEMENT_HOST};
                 proxy_pass http://entity_management/entity/$1$is_args$args;
             }
 
             # Manifest API
             location ~ ^/presentation/(.*)/manifest$ {
-                proxy_set_header Host ${
-                    MANIFEST_API_HOST
-                };
+                proxy_set_header Host ${MANIFEST_API_HOST};
                 proxy_pass http://manifest_api/presentation/$1/manifest$is_args$args;
             }
 
             # Fulltext API
             location ~ ^/(fulltext|presentation)/(.*) {
-                proxy_set_header Host ${
-                    FULLTEXT_API_HOST
-                };
+                proxy_set_header Host ${FULLTEXT_API_HOST};
                 proxy_pass http://fulltext_api/presentation/$2$is_args$args;
             }
 
             # Recommendation API
             location ~ ^/recommend/(.*) {
-                proxy_set_header Host ${
-                    RECOMMENDATION_API_HOST
-                };
+                proxy_set_header Host ${RECOMMENDATION_API_HOST};
                 proxy_pass http://recommendation_api/recommend/$1$is_args$args;
             }
 
             # Recommendation API (alternative path)
             location ~ ^/set/(.*)/recommend {
-                proxy_set_header Host ${
-                    RECOMMENDATION_API_HOST
-                };
+                proxy_set_header Host ${RECOMMENDATION_API_HOST};
                 proxy_pass http://recommendation_api/recommend/set/$1$is_args$args;
             }
 
             # Sets API
             location ~ ^/set/(.*) {
-                proxy_set_header Host ${
-                    SET_API_HOST
-                };
+                proxy_set_header Host ${SET_API_HOST};
                 proxy_pass http://set_api/set/$1$is_args$args;
             }
         }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -74,6 +74,7 @@ http {
 
     upstream translation_api {
         keepalive 10;
+        # Translation API enforces https
         server ${TRANSLATION_API_HOST}:443;
     }
 
@@ -107,22 +108,10 @@ http {
             return 200 '{"status":"healthy"}';
         }
 
-        location ~* ^/test/(.*) {
-            return 200 '$1';
-        }
-
         # no rewrite needed for proxying HOST requests
         location ~* ^/translation/(translate|detect) {
             proxy_set_header Host ${TRANSLATION_API_HOST};
             proxy_pass https://translation_api/$1;
-        }
-
-
-        # Tightened this one up to stop the weird redirection to the broken Swagger url in the index.html of the translation API
-        location /translation/actuator/info {
-            rewrite ^/translation/ /actuator/info break;
-            proxy_set_header Host ${TRANSLATION_API_HOST};
-            proxy_pass https://translation_api;
         }
 
         # Newspaper search

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -84,7 +84,7 @@ http {
 
     upstream keycloak {
         keepalive 10;
-        server ${KEYCLOAK_HOST};
+        server ${KEYCLOAK_HOST}:443;
     }
 
 

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -228,11 +228,18 @@ http {
 
 
             # EA-3761
-            location ~ ^/(auth)/?(protocol/openid-connect|account)?(.*)? {
-                set $openid $1/realms/europeana/$2$3;
+#             location ~ ^/(auth)/?(protocol/openid-connect|account)?(.*)? {
+#                 set $authPath $1/realms/europeana/$2$3;
+#                 proxy_set_header Host ${KEYCLOAK_HOST};
+#                 add_header 'X-Wickie' "$authPath" always;
+#                 proxy_pass https://keycloak/$authPath;
+#             }
+
+            location ~ ^/(auth)(/realms/europeana)(/protocol/openid-connect|/account)?(.*)? {
+                set $authPath $1/realms/europeana/$3$4;
                 proxy_set_header Host ${KEYCLOAK_HOST};
-                add_header 'X-Wickie' "$openid" always;
-                proxy_pass https://keycloak/$openid;
+                add_header 'X-Wickie' "$authPath" always;
+                proxy_pass https://keycloak/$authPath;
             }
 
             location ~* /translation/(.*) {

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -74,7 +74,7 @@ http {
 
     upstream translation_api {
         keepalive 10;
-        server ${TRANSLATION_API_HOST};
+        server ${TRANSLATION_API_HOST}:443;
     }
 
     upstream newspaper_api {
@@ -108,22 +108,17 @@ http {
             return 200 '{"status":"healthy"}';
         }
 
-        # Translation
-        location ~* ^/translation/(.*) {
+        # no rewrite needed for proxying HOST requests
+        location ~* ^/translation/(translate|detect) {
             proxy_set_header Host ${TRANSLATION_API_HOST};
-            proxy_pass http://translation_api/$1;
+            proxy_pass https://translation_api/$1;
         }
 
-        # possible fix 
-#         location /translation {
-#             proxy_set_header Authorization $http_authorization;
-#             proxy_pass_header Authorization;
-#             proxy_set_header Host $proxy_host;
-#             proxy_ssl_server_name on;
-#
-# #             proxy_pass https://$http_x_forwarded_to;
-#             proxy_pass https://translation_api;
-#         }
+        location ~* /translation/(.*) {
+            rewrite ^/translation/ /$1 break;
+            proxy_set_header Host ${TRANSLATION_API_HOST};
+            proxy_pass https://translation_api/$1;
+        }
 
         # Newspaper search
         location = /fulltext/search.json {

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -84,7 +84,7 @@ http {
 
 
     server {
-        listen 443 default_server;
+        listen 80 default_server;
 #         server_name ${API_GATEWAY_HOST};
 #         return 308 https://$host$request_uri;
 #     }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -227,17 +227,12 @@ http {
 
 
             # EA-3761
-            location ~ ^/(auth)/(protocol/openid-connect|account) {
-                set $openid $1/realms/europeana/$2;
+            location ~ ^/(auth)/?(protocol/openid-connect|account)?(.*)? {
+                set $openid $1/realms/europeana/$2$3;
                 proxy_set_header Host ${KEYCLOAK_HOST};
+                add_header 'X-Wickie' "$openid" always;
                 proxy_pass https://keycloak/$openid;
             }
-
-            location ~ ^/(auth)/?$ {
-                proxy_set_header Host ${KEYCLOAK_HOST};
-                proxy_pass https://keycloak/$1/;
-            }
-
 
             location ~* /translation/(.*) {
                 rewrite ^/translation/ /$1 break;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -161,10 +161,11 @@ http {
                 proxy_pass https://translation_api/$1;
             }
 
-            location ~* /translation/(.*) {
-                rewrite ^/translation/ /$1 break;
+            # Tightened this one up to stop the weird redirection to the broken Swagger url in the index.html of the translation API
+            location /translation/actuator/info {
+                rewrite ^/translation/ /actuator/info break;
                 proxy_set_header Host ${TRANSLATION_API_HOST};
-                proxy_pass https://translation_api/$1;
+                proxy_pass https://translation_api;
             }
 
             # Newspaper search

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -121,15 +121,6 @@ http {
 
         include nginx.conf.d/*.conf;
 
-
-        server {
-            listen 8088 default_server;
-            server_name localhost;
-            root /usr/local/etc/nginx/public;
-            #         listen 80;
-            #         root /usr/share/nginx/html;
-            index index.html;
-
             # ----------------------------------------------------------
             #
 		    # Wide-open CORS config for nginx

--- a/public/console/docs/v2/search.json
+++ b/public/console/docs/v2/search.json
@@ -292,7 +292,7 @@
             "name": "SearchRequest",
             "required": true,
             "schema": {
-              "$ref": "https://api.europeana.eu/schema/json/search.schema.json#/definitions/SearchRequest"
+              "$ref": "../../../schema/json/record/search.schema.json#/definitions/SearchRequest"
             }
           }
         ],

--- a/public/console/docs/v3/annotation.json
+++ b/public/console/docs/v3/annotation.json
@@ -52,14 +52,14 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "ErrorResponse"    : { "$ref": "https://api.europeana.eu/schema/json/error.schema.json"             },
-            "RetrievalResponse": { "$ref": "https://api.europeana.eu/schema/json/annotation/model.schema.json"  },
-            "SearchResponse"   : { "$ref": "https://api.europeana.eu/schema/json/annotation/search.schema.json" }
+            "ErrorResponse"    : { "$ref": "../../../schema/json/error.schema.json"             },
+            "RetrievalResponse": { "$ref": "../../../schema/json/annotation/model.schema.json"  },
+            "SearchResponse"   : { "$ref": "../../../schema/json/annotation/search.schema.json" }
         },
         "parameters": {
             "identifier": {
@@ -95,18 +95,18 @@
                 }
             },
 
-            "query"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/query"    },
-            "qf"      : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/qf"       },
-            "sort"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/sort"     },
-            "page"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/page"     },
-            "pageSize": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/pageSize" },
-            "facet"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/facet"    }
+            "query"   : { "$ref": "common.json#/components/parameters/query"    },
+            "qf"      : { "$ref": "common.json#/components/parameters/qf"       },
+            "sort"    : { "$ref": "common.json#/components/parameters/sort"     },
+            "page"    : { "$ref": "common.json#/components/parameters/page"     },
+            "pageSize": { "$ref": "common.json#/components/parameters/pageSize" },
+            "facet"   : { "$ref": "common.json#/components/parameters/facet"    }
         },
         "responses": {
-            "200": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/200" },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" },
-            "404": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" }
+            "200": { "$ref": "common.json#/components/responses/200" },
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" },
+            "404": { "$ref": "common.json#/components/responses/401" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/common.json
+++ b/public/console/docs/v3/common.json
@@ -68,7 +68,7 @@
             }
         },
         "schemas": {
-            "ErrorResponse": { "$ref": "https://api.europeana.eu/schema/json/error.schema.json" }
+            "ErrorResponse": { "$ref": "../../../schema/json/error.schema.json" }
         },
         "parameters": {
             "datasetId": {

--- a/public/console/docs/v3/entity.json
+++ b/public/console/docs/v3/entity.json
@@ -52,14 +52,14 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "ErrorResponse"    : { "$ref": "https://api.europeana.eu/schema/json/error.schema.json"         },
-            "RetrievalResponse": { "$ref": "https://api.europeana.eu/schema/json/entity/model.schema.json"  },
-            "SearchResponse"   : { "$ref": "https://api.europeana.eu/schema/json/entity/search.schema.json" }
+            "ErrorResponse"    : { "$ref": "../../../schema/json/error.schema.json"         },
+            "RetrievalResponse": { "$ref": "../../../schema/json/entity/model.schema.json"  },
+            "SearchResponse"   : { "$ref": "../../../schema/json/entity/search.schema.json" }
         },
         "parameters": {
             "type": {
@@ -165,12 +165,12 @@
                     "example": 10
                 }
             },
-            "query"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/query"    },
-            "qf"      : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/qf"       },
-            "sort"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/sort"     },
-            "page"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/page"     },
-            "pageSize": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/pageSize" },
-            "facet"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/facet"    }
+            "query"   : { "$ref": "common.json#/components/parameters/query"    },
+            "qf"      : { "$ref": "common.json#/components/parameters/qf"       },
+            "sort"    : { "$ref": "common.json#/components/parameters/sort"     },
+            "page"    : { "$ref": "common.json#/components/parameters/page"     },
+            "pageSize": { "$ref": "common.json#/components/parameters/pageSize" },
+            "facet"   : { "$ref": "common.json#/components/parameters/facet"    }
         },
         "responses": {
             "200": {
@@ -181,9 +181,9 @@
                     }
                 }
             },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" },
-            "404": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" }
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" },
+            "404": { "$ref": "common.json#/components/responses/401" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/iiif.json
+++ b/public/console/docs/v3/iiif.json
@@ -60,25 +60,25 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "ManifestV2"      : { "$ref": "https://api.europeana.eu/schema/json/iiif/v2/manifest.schema.json" },
-            "ManifestV3"      : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/manifest.schema.json" },
-            "AnnoPageV2"      : { "$ref": "https://api.europeana.eu/schema/json/iiif/v2/fulltext.schema.json#/definitions/AnnotationPage"    },
-            "ResultPageV2"    : { "$ref": "https://api.europeana.eu/schema/json/iiif/v2/fulltext.schema.json#/definitions/ResultPage"        },
-            "AnnoV2"          : { "$ref": "https://api.europeana.eu/schema/json/iiif/v2/fulltext.schema.json#/definitions/Annotation"        },
-            "AnnoPagesV3"     : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/AnnotationSummary" },
-            "AnnoPageV3"      : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/AnnotationPage"    },
-            "ResultPageV3"    : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/ResultPage"        },
-            "AnnoV3"          : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/Annotation"        },
-            "FullTextResource": { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/FullTextResource"  },
-            "ErrorResponse"   : { "$ref": "https://api.europeana.eu/schema/json/error.schema.json" },
+            "ManifestV2"      : { "$ref": "../../../schema/json/iiif/v2/manifest.schema.json" },
+            "ManifestV3"      : { "$ref": "../../../schema/json/iiif/v3/manifest.schema.json" },
+            "AnnoPageV2"      : { "$ref": "../../../schema/json/iiif/v2/fulltext.schema.json#/definitions/AnnotationPage"    },
+            "ResultPageV2"    : { "$ref": "../../../schema/json/iiif/v2/fulltext.schema.json#/definitions/ResultPage"        },
+            "AnnoV2"          : { "$ref": "../../../schema/json/iiif/v2/fulltext.schema.json#/definitions/Annotation"        },
+            "AnnoPagesV3"     : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/AnnotationSummary" },
+            "AnnoPageV3"      : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/AnnotationPage"    },
+            "ResultPageV3"    : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/ResultPage"        },
+            "AnnoV3"          : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/Annotation"        },
+            "FullTextResource": { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/FullTextResource"  },
+            "ErrorResponse"   : { "$ref": "../../../schema/json/error.schema.json" },
             
-            "LanguageList"            : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/LanguageList"        },
-            "TextGranularityList"     : { "$ref": "https://api.europeana.eu/schema/json/iiif/v3/fulltext.schema.json#/definitions/TextGranularityList" }
+            "LanguageList"            : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/LanguageList"        },
+            "TextGranularityList"     : { "$ref": "../../../schema/json/iiif/v3/fulltext.schema.json#/definitions/TextGranularityList" }
         },
         "parameters": {
             "datasetId": {
@@ -183,9 +183,9 @@
             }
         },
         "responses": {
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" },
-            "404": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/404" }
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" },
+            "404": { "$ref": "common.json#/components/responses/404" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/ld.json
+++ b/public/console/docs/v3/ld.json
@@ -36,9 +36,14 @@
         }
     ],
     "components": {
+        "securitySchemes": {
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
+        },
         "parameters": {
-            "datasetId" : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/datasetId"      },
-            "recordId"  : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/recordId"       },
+            "datasetId" : { "$ref": "common.json#/components/parameters/datasetId"      },
+            "recordId"  : { "$ref": "common.json#/components/parameters/recordId"       },
             "entityType": { "$ref": "https://api.europeana.eu/console/docs/v3/entity.json#/components/parameters/type"           },
             "entityId"  : { "$ref": "https://api.europeana.eu/console/docs/v3/entity.json#/components/parameters/identifier"     },
             "annoId"    : { "$ref": "https://api.europeana.eu/console/docs/v3/annotation.json#/components/parameters/identifier" }

--- a/public/console/docs/v3/record.json
+++ b/public/console/docs/v3/record.json
@@ -48,13 +48,13 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "parameters": {
-            "datasetId": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/datasetId" },
-            "recordId" : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/recordId" }
+            "datasetId": { "$ref": "common.json#/components/parameters/datasetId" },
+            "recordId" : { "$ref": "common.json#/components/parameters/recordId" }
         }
     },
     "paths": {
@@ -91,8 +91,8 @@
                 ],
                 "responses": {
                     "200": { "description": "The request was executed successfully." },
-                    "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-                    "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" }
+                    "400": { "$ref": "common.json#/components/responses/400" },
+                    "401": { "$ref": "common.json#/components/responses/401" }
                 }
             }
         }

--- a/public/console/docs/v3/search.json
+++ b/public/console/docs/v3/search.json
@@ -59,32 +59,32 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "ErrorResponse": { "$ref": "https://api.europeana.eu/schema/json/error.schema.json"                                    },
-            "SearchRequest": { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json"                            },
-            "Boost"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Boost"         },
-            "Callback"     : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Callback"      },
-            "ColourPalette": { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/ColourPalette" },
-            "Cursor"       : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Cursor"        },
-            "Facet"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Facet"         },
-            "HitFl"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/HitFl"         },
-            "HitSelectors" : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/HitSelectors"  },
-            "LandingPage"  : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/LandingPage"   },
-            "Media"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Media"         },
-            "Profile"      : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Profile"       },
-            "Query"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Query"         },
-            "QF"           : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/QF"            },
-            "Reusability"  : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Reusability"   },
-            "Rows"         : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Rows"          },
-            "Sort"         : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Sort"          },
-            "Start"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Start"         },
-            "TextFulltext" : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/TextFulltext"  },
-            "Theme"        : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Theme"         },
-            "Thumbnail"    : { "$ref": "https://api.europeana.eu/schema/json/record/search.schema.json#/definitions/Thumbnail"     }
+            "ErrorResponse": { "$ref": "../../../schema/json/error.schema.json"                                    },
+            "SearchRequest": { "$ref": "../../../schema/json/record/search.schema.json"                            },
+            "Boost"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Boost"         },
+            "Callback"     : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Callback"      },
+            "ColourPalette": { "$ref": "../../../schema/json/record/search.schema.json#/definitions/ColourPalette" },
+            "Cursor"       : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Cursor"        },
+            "Facet"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Facet"         },
+            "HitFl"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/HitFl"         },
+            "HitSelectors" : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/HitSelectors"  },
+            "LandingPage"  : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/LandingPage"   },
+            "Media"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Media"         },
+            "Profile"      : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Profile"       },
+            "Query"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Query"         },
+            "QF"           : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/QF"            },
+            "Reusability"  : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Reusability"   },
+            "Rows"         : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Rows"          },
+            "Sort"         : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Sort"          },
+            "Start"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Start"         },
+            "TextFulltext" : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/TextFulltext"  },
+            "Theme"        : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Theme"         },
+            "Thumbnail"    : { "$ref": "../../../schema/json/record/search.schema.json#/definitions/Thumbnail"     }
         },
         "parameters": {
             "Query": {
@@ -243,8 +243,8 @@
             "200": {
                 "description": "The request was executed successfully"
             },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" }
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/set.json
+++ b/public/console/docs/v3/set.json
@@ -56,15 +56,15 @@
     ],
     "components": {
         "securitySchemes": {
-            "X-Api-Key": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/X-Api-Key" },
-            "wskey"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/wskey"     },
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token"     }
+            "X-Api-Key": { "$ref": "common.json#/components/securitySchemes/X-Api-Key" },
+            "wskey"    : { "$ref": "common.json#/components/securitySchemes/wskey" },
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "ErrorResponse" : { "$ref": "https://api.europeana.eu/schema/json/error.schema.json"      },
-            "ModelResponse" : { "$ref": "https://api.europeana.eu/schema/json/set/model.schema.json#/definitions/Set"     },
-            "PageResponse"  : { "$ref": "https://api.europeana.eu/schema/json/set/model.schema.json#/definitions/SetPage" },
-            "SearchResponse": { "$ref": "https://api.europeana.eu/schema/json/set/search.schema.json" }
+            "ErrorResponse" : { "$ref": "../../../schema/json/error.schema.json"      },
+            "ModelResponse" : { "$ref": "../../../schema/json/set/model.schema.json#/definitions/Set"     },
+            "PageResponse"  : { "$ref": "../../../schema/json/set/model.schema.json#/definitions/SetPage" },
+            "SearchResponse": { "$ref": "../../../schema/json/set/search.schema.json" }
         },
         "parameters": {
             "identifier": {
@@ -124,18 +124,18 @@
                 }
             },
 
-            "query"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/query"    },
-            "qf"      : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/qf"       },
-            "sort"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/sort"     },
-            "page"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/page"     },
-            "pageSize": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/pageSize" },
-            "facet"   : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/parameters/facet"    }
+            "query"   : { "$ref": "common.json#/components/parameters/query"    },
+            "qf"      : { "$ref": "common.json#/components/parameters/qf"       },
+            "sort"    : { "$ref": "common.json#/components/parameters/sort"     },
+            "page"    : { "$ref": "common.json#/components/parameters/page"     },
+            "pageSize": { "$ref": "common.json#/components/parameters/pageSize" },
+            "facet"   : { "$ref": "common.json#/components/parameters/facet"    }
         },
         "responses": {
-            "200": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/200" },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" },
-            "404": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" }
+            "200": { "$ref": "common.json#/components/responses/200" },
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" },
+            "404": { "$ref": "common.json#/components/responses/401" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/thumbnail.json
+++ b/public/console/docs/v3/thumbnail.json
@@ -56,8 +56,8 @@
             "200_head": {
                 "description": "The image exits and can be retrieved."
             },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "404": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/404" }
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "404": { "$ref": "common.json#/components/responses/404" }
         }
     },
     "paths": {

--- a/public/console/docs/v3/translation.json
+++ b/public/console/docs/v3/translation.json
@@ -47,21 +47,21 @@
     ],
     "components": {
         "securitySchemes": {
-            "token"    : { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/securitySchemes/token" }
+            "token"    : { "$ref": "common.json#/components/securitySchemes/token" }
         },
         "schemas": {
-            "LangDetectRequest"  : { "$ref": "https://api.europeana.eu/schema/json/translation/ws.schema.json#/definitions/LangDetectRequest"   },
-            "LangDetectResponse" : { "$ref": "https://api.europeana.eu/schema/json/translation/ws.schema.json#/definitions/LangDetectResponse"  },
-            "TranslationRequest" : { "$ref": "https://api.europeana.eu/schema/json/translation/ws.schema.json#/definitions/TranslationRequest"  },
-            "TranslationResponse": { "$ref": "https://api.europeana.eu/schema/json/translation/ws.schema.json#/definitions/TranslationResponse" }
+            "LangDetectRequest"  : { "$ref": "../../../schema/json/translation/ws.schema.json#/definitions/LangDetectRequest"   },
+            "LangDetectResponse" : { "$ref": "../../../schema/json/translation/ws.schema.json#/definitions/LangDetectResponse"  },
+            "TranslationRequest" : { "$ref": "../../../schema/json/translation/ws.schema.json#/definitions/TranslationRequest"  },
+            "TranslationResponse": { "$ref": "../../../schema/json/translation/ws.schema.json#/definitions/TranslationResponse" }
         },
         "responses": {
             "200": {
                 "description": "The thumbnail was returned successfully."
             },
-            "400": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/400" },
-            "401": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/401" },
-            "403": { "$ref": "https://api.europeana.eu/console/docs/v3/common.json#/components/responses/403" }
+            "400": { "$ref": "common.json#/components/responses/400" },
+            "401": { "$ref": "common.json#/components/responses/401" },
+            "403": { "$ref": "common.json#/components/responses/403" }
         }
     },
     "paths": {


### PR DESCRIPTION
This PR contains changes for:

EA-3782 (configuration changes for proxying)
EA-3771 (reverse proxying POST requests, eg for translation API)
EA-3732 (Reverse proxying Translation API, handling the HTTPS redirect on the translation API, reverse proxy for Fulltext Search - known issue: /actuator/info for translation API does not work because the Swagger UI redirects the request)

A hotfix for adding the JSON-LD mimetype

There are also a number of changes in the static json files (/public/console/docs/ ) for Swagger. These for deployed for Hugo to test, there is no need to review them. 

This branch is now deployed on the test cluster (April 10)